### PR TITLE
some optimize

### DIFF
--- a/src/renderer/extensions/rule-editor/components/rule-list/index.tsx
+++ b/src/renderer/extensions/rule-editor/components/rule-list/index.tsx
@@ -291,7 +291,9 @@ export const RuleList = (props: Props) => {
                                                 switchRule(index);
                                             };
 
-                                            const handleDoubleClick = () => {
+                                            const handleDoubleClick = (rename: boolean | undefined) => {
+                                                if (rename) return;
+
                                                 toggleRuleEnabledRef.current(index);
                                             };
 
@@ -357,7 +359,7 @@ export const RuleList = (props: Props) => {
                                                     className={className}
                                                     onClick={handleClick}
                                                     onContextMenu={handleContextMenu}
-                                                    onDoubleClick={handleDoubleClick}
+                                                    onDoubleClick={() => handleDoubleClick(item.rename)}
                                                 >
                                                     {item.rename ? (
                                                         <Input

--- a/src/renderer/extensions/setting/index.less
+++ b/src/renderer/extensions/setting/index.less
@@ -1,5 +1,6 @@
 .lightproxy-setting {
     padding: 50px;
+    margin-top: 30px;
     line-height: 25px;
     font-weight: bold;
     font-size: 16px;    

--- a/src/renderer/extensions/setting/index.tsx
+++ b/src/renderer/extensions/setting/index.tsx
@@ -2,6 +2,7 @@ import { Extension } from '../../extension';
 import React from 'react';
 import { SettingForm } from './components/setting-form';
 import { useTranslation } from 'react-i18next';
+import { CoreAPI } from '../../core-api';
 
 const SettingFormComponent = SettingForm as any;
 
@@ -17,13 +18,26 @@ export class Setting extends Extension {
     panelComponent() {
         const SettingPanelComponent = () => {
             const { t } = useTranslation();
+            const settings = CoreAPI.store.get('settings') || {};
+
+            if (!settings.updateChannel) {
+                settings.updateChannel = 'stable';
+            }
+
+            if (!(settings.softwareWhiteList === false)) {
+                settings.softwareWhiteList = true;
+            }
+
+            if (!settings.defaultPort) {
+                settings.defaultPort = 12888;
+            }
 
             return (
                 <div className="lightproxy-setting no-drag">
                     {/* <p>LightProxy poweredby Whistle & Electron</p>
                     <p>Made with love by IFE</p>
                     <p>Version {version}</p> */}
-                    <SettingFormComponent t={t} />
+                    <SettingFormComponent t={t} settings={settings} />
                 </div>
             );
         };


### PR DESCRIPTION
1、在重命名规则时，修复双击input框也能启用或停用规则的问题
2、SettingForm改为由外部组件传入settings，避免首次进入设置页面就弹出“已保存”
3、SettingForm的onValuesChange添加防抖处理，避免input时频繁保存