### PR TITLE
fix: res-delay

### DIFF
--- a/src/renderer/extensions/rule-editor/components/card/index.tsx
+++ b/src/renderer/extensions/rule-editor/components/card/index.tsx
@@ -54,7 +54,7 @@ multiple line
         value: 'res-delay',
         title: 'Delay response',
         icon: 'coffee',
-        content: `\${1:${MOCK_PATH}} resCors://
+        content: `\${1:${MOCK_PATH}} resDelay://
 `,
     },
     {


### PR DESCRIPTION
fix: 修复快捷插入规则里res-delay的模板错误的问题