### PR TITLE
refactor: system proxy enable or disable

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -15,6 +15,9 @@ import electronIsDev from 'electron-is-dev';
 import path from 'path';
 import { LIGHTPROXY_FILES_DIR } from './const';
 import { app, nativeTheme, BrowserWindow } from 'electron';
+import Store from 'electron-store';
+
+const store = new Store();
 
 interface SwpanModuleProp {
     moduleId: string;
@@ -146,6 +149,7 @@ export async function initIPC(mainWindow: BrowserWindow) {
     await BoardcastManager.getInstance();
 
     exitHook(async () => {
-        await setSystemProxy(0);
+        const onlineStatus = store.get('onlineStatus', 'ready');
+        onlineStatus === 'online' && (await setSystemProxy(0));
     });
 }

--- a/src/renderer/extensions/whistle/index.tsx
+++ b/src/renderer/extensions/whistle/index.tsx
@@ -86,8 +86,8 @@ export class WhistleExntension extends Extension {
                     this.coreAPI.eventEmmitter.emit('whistle-get-devtool-port-response', this.mDevtoolPort);
 
                     // ... ready to set system proxy
-                    const onlineStatus = this.coreAPI.store.get('onlineStatus');
-                    toggleSystemProxy(onlineStatus || 'online', port, this.coreAPI);
+                    const onlineStatus = this.coreAPI.store.get('onlineStatus', 'ready');
+                    onlineStatus === 'online' && toggleSystemProxy(onlineStatus, port, this.coreAPI);
 
                     this.coreAPI.eventEmmitter.on('lightproxy-toggle-system-proxy', async () => {
                         const onlineStatus = this.coreAPI.store.get('onlineStatus');


### PR DESCRIPTION
1. When the app start, only onlineStatus is online to enable the system proxy
2. When the app exit, only onlineStatus is online to disable the system proxy