### PR TITLE
fix #151, open untrust url in external browser, and make view all works

### DIFF
--- a/vendor/whistle/biz/webui/htdocs/editor.html
+++ b/vendor/whistle/biz/webui/htdocs/editor.html
@@ -14,6 +14,13 @@ html, body, .main {padding: 0; margin: 0; height: 100%; overflow: hidden;}
 ::-webkit-scrollbar-track,::-webkit-scrollbar-thumb { border-left:2px solid transparent; border-right:2px solid transparent;}
 ::-webkit-scrollbar-track:hover{ background-clip:padding-box; background-color:rgba(0,0,0,.15);}
 textarea {outline: none; resize: none; display: block; padding: 6px; font-size: 12px; width: 100%; height: 100%; border: none; box-sizing: border-box; font-family: consolas, monospace;}
+
+@media (prefers-color-scheme: dark) {
+	textarea {
+		background-color: #292626;
+		color: white;
+	}
+}
 </style>
 </head>
 <body>

--- a/vendor/whistle/biz/webui/htdocs/editor.html
+++ b/vendor/whistle/biz/webui/htdocs/editor.html
@@ -13,7 +13,7 @@ html, body, .main {padding: 0; margin: 0; height: 100%; overflow: hidden;}
 ::-webkit-scrollbar-thumb:hover{ background-clip:padding-box; background-color:rgba(0,0,0,.7); border-radius:8px;}
 ::-webkit-scrollbar-track,::-webkit-scrollbar-thumb { border-left:2px solid transparent; border-right:2px solid transparent;}
 ::-webkit-scrollbar-track:hover{ background-clip:padding-box; background-color:rgba(0,0,0,.15);}
-textarea {resize: none; display: block; padding: 6px; font-size: 12px; width: 100%; height: 100%; border: none; box-sizing: border-box; font-family: consolas, monospace;}
+textarea {outline: none; resize: none; display: block; padding: 6px; font-size: 12px; width: 100%; height: 100%; border: none; box-sizing: border-box; font-family: consolas, monospace;}
 </style>
 </head>
 <body>

--- a/vendor/whistle/biz/webui/htdocs/index.html
+++ b/vendor/whistle/biz/webui/htdocs/index.html
@@ -38,10 +38,18 @@
 
 <script>
     const require = parent && parent.window && parent.window.require;
+    let lastCleanup;
+
     if (require) {
         const originOpen = window.open;
         window.open = (url) => {
             if (url === 'editor.html') {
+
+                if (lastCleanup) {
+                    lastCleanup();
+                    lastCleanup = null;
+                }
+
                 const container = document.createElement('iframe');
                 container.src = url;
                 container.style = `position: fixed; left: 10px; top: 50px; width: 90%; height: 80%; z-index: 1000`;
@@ -60,10 +68,13 @@
     border: solid 1px red !important;
     cursor: pointer;`.replace('\n', '');
 
-                closeBtn.onclick = () => {
+                const cleanup = () => {
                     container.remove();
                     closeBtn.remove();
                 };
+
+                closeBtn.onclick = cleanup;
+                lastCleanup = cleanup;
 
                 document.body.appendChild(closeBtn);
 

--- a/vendor/whistle/biz/webui/htdocs/index.html
+++ b/vendor/whistle/biz/webui/htdocs/index.html
@@ -32,8 +32,55 @@
     .w-req-data-list .w-has-rules td, .w-req-data-list .w-has-rules th {
         color: #69c0ff !important;
     }
+
 }
 </style>
+
+<script>
+    const require = parent && parent.window && parent.window.require;
+    if (require) {
+        const originOpen = window.open;
+        window.open = (url) => {
+            if (url === 'editor.html') {
+                const container = document.createElement('iframe');
+                container.src = url;
+                container.style = `position: fixed; left: 10px; top: 50px; width: 90%; height: 80%; z-index: 1000`;
+                document.body.appendChild(container);
+
+                const closeBtn = document.createElement('div');
+                closeBtn.innerText = 'X';
+                closeBtn.style = `position: fixed;
+    left: 10px;
+    top: 30px;
+    display: inline-block;
+    background: black;
+    color: white;
+    z-index: 1000;
+    padding: 3px 20px;
+    border: solid 1px red !important;
+    cursor: pointer;`.replace('\n', '');
+
+                closeBtn.onclick = () => {
+                    container.remove();
+                    closeBtn.remove();
+                };
+
+                document.body.appendChild(closeBtn);
+
+                return {
+                    set setValue(val) {
+                        container.contentWindow.setValue = val;
+                    },
+                    set getValue(val) {
+                        container.contentWindow.getValue = val;
+                    }
+                }
+            } else {
+                require('electron').remote.shell.openExternal(url);
+            }
+        };
+    }
+</script>
 
 <title>Whistle Web Debugger</title>
 </head>

--- a/vendor/whistle/biz/webui/htdocs/index.html
+++ b/vendor/whistle/biz/webui/htdocs/index.html
@@ -50,33 +50,64 @@
                     lastCleanup = null;
                 }
 
+                const floatLayer = document.createElement('div');
+                floatLayer.style = `
+                  position: fixed;
+                  width: 90%;
+                  height: 80%;
+                  left: 5%;
+                  top: 10%;
+                  z-index: 1000;
+                  display: flex;
+                  flex-direction: column;
+                  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, .1), 0 10px 10px -5px rgba(0, 0, 0, .04);
+                  border: 1px solid #c0c0c0;
+                  border-radius: 6px;
+                  overflow: hidden;
+                  background-color: #fff;
+                `.replace('\n', '');
+                const layerBar = document.createElement('div');
+                layerBar.style = `
+                  width: 100%;
+                  height: 0;
+                  flex: 0 0 28px;
+                  background-color: #f5f5f5;
+                  display: flex;
+                  align-items: center;
+                  padding: 0 10px;
+                `.replace('\n', '');
                 const container = document.createElement('iframe');
                 container.src = url;
-                container.style = `position: fixed; left: 10px; top: 50px; width: 90%; height: 80%; z-index: 1000`;
-                document.body.appendChild(container);
+                container.style = `
+                  width: 100%;
+                  flex: 1;
+                  border: 0;
+                `.replace('\n', '');
+                floatLayer.appendChild(layerBar);
+                floatLayer.appendChild(container);
+                document.body.appendChild(floatLayer);
 
                 const closeBtn = document.createElement('div');
-                closeBtn.innerText = 'X';
-                closeBtn.style = `position: fixed;
-    left: 10px;
-    top: 30px;
-    display: inline-block;
-    background: black;
-    color: white;
-    z-index: 1000;
-    padding: 3px 20px;
-    border: solid 1px red !important;
-    cursor: pointer;`.replace('\n', '');
+                closeBtn.style = `
+                  cursor: pointer;
+                  height: 13px;
+                  width: 13px;
+                  border-radius: 50%;
+                  border: 1px solid #e2463f;
+                  background-color: #ff5f57;
+                `.replace('\n', '');
 
                 const cleanup = () => {
-                    container.remove();
                     closeBtn.remove();
+                    layerBar.remove();
+                    container.remove();
+                    floatLayer.remove();
                 };
 
                 closeBtn.onclick = cleanup;
                 lastCleanup = cleanup;
 
-                document.body.appendChild(closeBtn);
+                layerBar.appendChild(closeBtn);
 
                 return {
                     set setValue(val) {

--- a/vendor/whistle/biz/webui/htdocs/index.html
+++ b/vendor/whistle/biz/webui/htdocs/index.html
@@ -94,7 +94,7 @@
                   width: 13px;
                   border-radius: 50%;
                   border: 1px solid #e2463f;
-                  background-color: #ff5f57;
+                  background-color: #ff5f57 !important;
                 `.replace('\n', '');
 
                 const cleanup = () => {


### PR DESCRIPTION
- whistle 抓包界面在外部浏览器打开不信任的窗口，修复安全问题 #151
- 通过 iframe mock window.open 修复 View All 功能

![image](https://user-images.githubusercontent.com/5436704/84382700-99a55600-ac1d-11ea-81ef-e5de47c7477e.png)

![image](https://user-images.githubusercontent.com/5436704/84382706-9d38dd00-ac1d-11ea-8d1c-3cded603d850.png)
