### PR TITLE
fix docs jump link error

### DIFF
--- a/docs/docs/doc/getting-started.zh-CN.md
+++ b/docs/docs/doc/getting-started.zh-CN.md
@@ -69,7 +69,7 @@ LightProxy 是一款基于 `whistle` 的本地代理抓包软件
 
 ## 更多规则
 
-除了多行字符串语法外， `LightProxy` 语法就是 `whistle` 语法，可以直接参考 `whistle` 的规则文档：https://wproxy.org/whistle/principle.html](https://wproxy.org/whistle/principle.html)
+除了多行字符串语法外， `LightProxy` 语法就是 `whistle` 语法，可以直接参考 `whistle` 的规则文档：[https://wproxy.org/whistle/principle.html](https://wproxy.org/whistle/principle.html)
 
 ## 反馈
 

--- a/docs/docs/rules/match.zh-CN.md
+++ b/docs/docs/rules/match.zh-CN.md
@@ -80,7 +80,7 @@ http://test.com/test/ (test)
 # 匹配所有请求
 /./ (test)
 
-# 匹配url里面包含摸个关键字的请求
+# 匹配url里面包含某个关键字的请求
 /keyword/ (test)
 
 # 通过正则匹配，同样的 $1~$9 捕获分组，$0 表示整个 URL

--- a/vendor/whistle/docs/zh/pattern.md
+++ b/vendor/whistle/docs/zh/pattern.md
@@ -48,7 +48,7 @@ whistle的匹配模式(`pattern`)大体可以分成 **域名、路径、正则�
 	#匹配所有请求
 	* operatorURI
 
-	#匹配url里面包含摸个关键字的请求，且忽略大小写
+	#匹配url里面包含某个关键字的请求，且忽略大小写
 	/keyword/i operatorURI
 
 	# 利用子匹配把url里面的参数带到匹配的操作uri


### PR DESCRIPTION
The link format is wrong and the corresponding page cannot be opened